### PR TITLE
界面添加单独class 首页形成单独的render

### DIFF
--- a/app/components/header-index.js
+++ b/app/components/header-index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+let Header = (props) => {
+	return (
+		<header>
+			<ul>
+				{
+					props.data.map((item, index) => {
+						return (
+							<li key={index}>
+								<a href={item.href}>{item.name}</a>
+							</li>
+						);
+					})
+				}
+			</ul>
+		</header>
+	);
+}
+
+export default Header;

--- a/app/pages/index.js
+++ b/app/pages/index.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import PageLayout from '../core/page-layout.js';
+import { Footer } from '../../src/layout';
+import Header from '../components/header-index.js';
 
 export default class Page extends PageLayout {
-    renderMain() {
-        return (
+	render() {
+		return (
             <div>
+				<Header data={this.system.navigation} />
                 <section>Cat Meow React 系统开发框架<a href="/react">开始</a></section>
                 <section>最佳实践 自2015年第三季度开始中后台设计，服务于生产环境的稳定框架。<a href="/practice">了解更多</a></section>
                 <section>设计思路</section>
                 <section>脱离业务逻辑束缚的基础组件，不断打磨的功能需求</section>
                 <section>Cute Smart</section>
+				<Footer system={this.system} />
             </div>
         );
-    }
+	}
 }

--- a/server/controllers/component.js
+++ b/server/controllers/component.js
@@ -22,7 +22,7 @@ export default class Component extends Controller {
 		let readme = fs.readFileSync(path.join(componentPath, 'readme.md'), 'utf-8');
 
 		this.render({
-			page: '/components',
+			page: 'component',
 			script: 'bootstrap',
 			metadata: JSON.stringify({
 				page: 'component',

--- a/server/controllers/main.js
+++ b/server/controllers/main.js
@@ -8,7 +8,7 @@ import marked from 'marked';
 export default class Main extends Controller {
     *index() {
         this.render({
-            page: '/',
+            page: 'index',
             script: 'bootstrap',
             path: config.path,
             metadata: JSON.stringify({
@@ -19,7 +19,7 @@ export default class Main extends Controller {
 
     *test() {
         this.render({
-            page: '/test',
+            page: 'test',
             script: 'bootstrap',
             metadata: JSON.stringify({
                 page: 'test'
@@ -37,7 +37,7 @@ export default class Main extends Controller {
 		let docFile = fs.existsSync(docName) ? fs.readFileSync(docName, 'utf8') : '';
 
         this.render({
-            page: '/test',
+            page: 'common-md',
             script: 'bootstrap',
             metadata: JSON.stringify({
                 page: 'common-md',
@@ -55,10 +55,10 @@ export default class Main extends Controller {
         let { request } = this.ctx;
 
         this.render({
-            page: '/test',
+            page: 'base',
             script: 'bootstrap',
             metadata: JSON.stringify({
-                page: 'common-md',
+                page: 'base',
                 url: request.url
             })
         });

--- a/server/views/default.html
+++ b/server/views/default.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Cat-Meow</title>
-  <meta charset="utf-8">
-  <link rel="stylesheet" href="/style/css/bootstrap.css">
-  <link rel="stylesheet" href="/style/css/index.css">
+	<title>Cat-Meow</title>
+	<meta charset="utf-8">
+	<link rel="stylesheet" href="/style/css/bootstrap.css">
+	<link rel="stylesheet" href="/style/css/index.css">
 </head>
 <body>
-  <div id="app"/></div>
-  <script>
-    window.MYM = <%= metadata %>;
-  </script>
-  <script src="/scripts/<%= script %>.js"></script>
-  <script src="http://localhost:35729/livereload.js"></script>
+	<div id="app" class="page-<%= page %>"/></div>
+	<script>
+		window.MYM = <%= metadata %>;
+	</script>
+	<script src="/scripts/<%= script %>.js"></script>
+	<script src="http://localhost:35729/livereload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
todo:
自定义模板文件page-layout的定制性不够强，想要提供给用户这样的需求，在有自定义需求的情况下，仍然不需要覆盖整个render()函数来简单地达到目的
